### PR TITLE
fix: critical runtime bugs in blankScreen, createLand and storage helpers

### DIFF
--- a/src/pages/blankScreen/index.js
+++ b/src/pages/blankScreen/index.js
@@ -1,25 +1,21 @@
-import { 
-    View, 
-    Image, 
-    Text, 
-    StatusBar
-} from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import React, { useEffect } from 'react';
+import { Image, StatusBar, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
-export default function blankScreen() {
-    let navigation = useNavigation()
+
+export default function BlankScreen() {
+    const navigation = useNavigation();
+
     useEffect(() => {
-        async function returning(){
-            await sleep(2000)
-            navigation.navigate('Home')
-        }
-        returning()
-        
-    }, [])
+        const timer = setTimeout(() => {
+            navigation.navigate('Home');
+        }, 2000);
+        return () => clearTimeout(timer);
+    }, [navigation]);
 
-    return <>
-            <StatusBar backgroundColor="#00753E" barStyle='light-content' />
+    return (
+        <>
+            <StatusBar backgroundColor="#00753E" barStyle="light-content" />
             <View style={{
                 flex: 1,
                 alignItems: 'center',
@@ -27,10 +23,11 @@ export default function blankScreen() {
                 backgroundColor: '#000',
             }}>
                 <Image
-                style={{width: 300, height: 200}}
-                source={{uri: 'https://media.giphy.com/media/VseXvvxwowwCc/giphy.gif'}} />
-                <Text style={{color:'#fff'}}>Buscando dados...</Text>
+                    style={{ width: 300, height: 200 }}
+                    source={{ uri: 'https://media.giphy.com/media/VseXvvxwowwCc/giphy.gif' }}
+                />
+                <Text style={{ color: '#fff' }}>Buscando dados...</Text>
             </View>
         </>
-} 
-
+    );
+}

--- a/src/pages/citySearch/index.js
+++ b/src/pages/citySearch/index.js
@@ -1,71 +1,42 @@
-import * as React from 'react';
+import React from 'react';
 import {
-  Text,
-  View,
-  FlatList,
   ActivityIndicator,
+  FlatList,
+  StatusBar,
+  Text,
   TouchableOpacity,
-  AsyncStorage,
-  StatusBar
+  View,
 } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import { SearchBar } from 'react-native-elements';
-import styles from "./styles";
+
+import styles from './styles';
+
+
 export default class CitySearch extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { isLoading: true, search: '' };
-    this.arrayholder = [];
+    this.state = { isLoading: true, search: '', dataSource: [] };
+    this.allCities = [];
   }
+
   componentDidMount() {
-    let responseJson = this.props.route.params.cities;
-    this.setState(
-      {
-        isLoading: false,
-        dataSource: responseJson ,
-      },
-      function() {
-        this.arrayholder = responseJson;
-      }
-    );
+    const cities = this.props.route?.params?.cities ?? [];
+    this.allCities = cities;
+    this.setState({ isLoading: false, dataSource: cities });
   }
 
-  search = text => {
-    console.log(text);
+  SearchFilterFunction = (text) => {
+    const upper = text.toUpperCase();
+    const filtered = this.allCities.filter((item) =>
+      (item.name || '').toUpperCase().includes(upper)
+    );
+    this.setState({ dataSource: filtered, search: text });
   };
-  clear = () => {
-    this.search.clear();
-  };
-  
+
   getCityById(id) {
-    return this.state.dataSource.filter(
-        (data) => data.id == id 
-    );
+    return this.allCities.find((data) => data.id === id);
   }
-
-  SearchFilterFunction(text) {
-    const newData = this.arrayholder.filter(function(item) {
-      const itemData = item.name ? item.name.toUpperCase() : ''.toUpperCase();
-      const textData = text.toUpperCase();
-      return itemData.indexOf(textData) > -1;
-    });
-
-    this.setState({
-      dataSource: newData,
-      search: text,
-    });
-  }
-
-  ListViewItemSeparator = () => {
-    return (
-      <View
-        style={{
-          height: 0.3,
-          width: '90%',
-          backgroundColor: '#080808',
-        }}
-      />
-    );
-  };
 
   render() {
     if (this.state.isLoading) {
@@ -75,46 +46,46 @@ export default class CitySearch extends React.Component {
         </View>
       );
     }
-    return (<>
-      <StatusBar backgroundColor="#00753E" barStyle='light-content' />
-      <View style={styles.viewStyle}>
-        
-        <SearchBar
-          round
-          searchIcon={{ size: 24 }}
-          inputStyle={styles.inputStyle}
-          containerStyle={styles.containerStyle}
-          placeholderTextColor={'#fff'}
-          onChangeText={text => this.SearchFilterFunction(text)}
-          onClear={text => this.SearchFilterFunction('')}
-          placeholder="Pesquise sua cidade..."
-          value={this.state.search}
-        />
-        <FlatList
-          data={this.state.dataSource}
-          // ItemSeparatorComponent={this.ListViewItemSeparator}
-          renderItem={({ item }) => (
-            <TouchableOpacity
-              onPress={async () => {
-                let city = this.getCityById(item.id)[0]
-                
-                await AsyncStorage.setItem('city', 
-                  JSON.stringify(city)
-                );
-                this.props.navigation.goBack()
-              }}
-
-              style={styles.item}>
-              <Text style={styles.textItem}>{item.name}</Text>
-            </TouchableOpacity>
-          )}
-          enableEmptySections={true}
-          style={{ marginTop: 10 }}
-          keyExtractor={(item, index) => index.toString()}
-        />
-      </View>
+    return (
+      <>
+        <StatusBar backgroundColor="#00753E" barStyle="light-content" />
+        <View style={styles.viewStyle}>
+          <SearchBar
+            round
+            searchIcon={{ size: 24 }}
+            inputStyle={styles.inputStyle}
+            containerStyle={styles.containerStyle}
+            placeholderTextColor={'#fff'}
+            onChangeText={(text) => this.SearchFilterFunction(text)}
+            onClear={() => this.SearchFilterFunction('')}
+            placeholder="Pesquise sua cidade..."
+            value={this.state.search}
+          />
+          <FlatList
+            data={this.state.dataSource}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                onPress={async () => {
+                  const city = this.getCityById(item.id);
+                  if (city) {
+                    await AsyncStorage.setItem('city', JSON.stringify(city));
+                  }
+                  this.props.navigation.goBack();
+                }}
+                style={styles.item}
+              >
+                <Text style={styles.textItem}>{item.name}</Text>
+              </TouchableOpacity>
+            )}
+            enableEmptySections
+            style={{ marginTop: 10 }}
+            keyExtractor={(item) => String(item.id)}
+            initialNumToRender={20}
+            maxToRenderPerBatch={20}
+            windowSize={10}
+          />
+        </View>
       </>
     );
   }
 }
-

--- a/src/pages/legislation/index.js
+++ b/src/pages/legislation/index.js
@@ -1,22 +1,32 @@
 import React from 'react';
-import { View, Text, Switch, ScrollView, TouchableOpacity, ActivityIndicator,
-AsyncStorage} from 'react-native';
-import {CheckBox} from "native-base";
+import {
+  ActivityIndicator,
+  ScrollView,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
+import { CheckBox } from 'native-base';
+import { Feather } from '@expo/vector-icons';
 import { useFormik } from 'formik';
 import { useNavigation } from '@react-navigation/native';
-import { Feather } from '@expo/vector-icons';
-import styles from './styles';
+
 import Header from '../../utils/header';
 import createControl from '../../utils/createControl';
 import createLand from '../../utils/createLand';
+import styles from './styles';
+
 
 export default function Legislation() {
-    const navigation = useNavigation()
-    const control = createControl
+    const navigation = useNavigation();
+    const control = createControl;
+
     const formik = useFormik({
         initialValues: {
             EnvironmentalLicensing: false,
-            CAR : false,
+            CAR: false,
             PresenceMaintenanceVegetation: false,
             NativeVegetationLegalReserve: false,
             AppAroundWaterCoursesWaterReservoirs: false,
@@ -27,222 +37,200 @@ export default function Legislation() {
             EnvironmentalRegularizationPlan: false,
             WaterGrant: false,
         },
-        handleSubmit: () => {},
-        onSubmit: async (values, {setSubmitting, setErrors}) => {
+        onSubmit: async (values, { setSubmitting }) => {
             setSubmitting(true);
-            let jsonValue = JSON.parse(await AsyncStorage.getItem('land'))
-            let JSONcontrol = JSON.parse(await AsyncStorage.getItem('control'))
-            let attributes = jsonValue.attributes!=null?jsonValue.attributes:{}
-            
-            for (var key in values)  {
-                attributes[key] = values[key]                
-            }
-            
             try {
-                jsonValue.edited = true
-                await createLand.update({
-                    ...jsonValue,
-                    attributes
-                })
-    
-                await control.update({
-                    ...JSONcontrol,
-                    'boolLegislation': true
-                })
+                const [landRaw, controlRaw] = await Promise.all([
+                    AsyncStorage.getItem('land'),
+                    AsyncStorage.getItem('control'),
+                ]);
+                const land = JSON.parse(landRaw);
+                const JSONcontrol = JSON.parse(controlRaw);
+                const attributes = { ...(land.attributes ?? {}), ...values };
+
+                land.edited = true;
+                await createLand.update({ ...land, attributes });
+                await control.update({ ...JSONcontrol, boolLegislation: true });
                 setSubmitting(false);
                 navigation.goBack();
             } catch (error) {
-                alert('Falha no armazenamento, tente mais uma vez.')
+                console.warn('[Legislation.onSubmit]', error);
+                alert('Falha no armazenamento, tente mais uma vez.');
                 setSubmitting(false);
                 navigation.goBack();
             }
         },
-      });
+    });
 
-    return <View style={styles.container} >
+    const setAppFlags = (value) => {
+        formik.setFieldValue('CAR', value);
+        formik.setFieldValue('NativeVegetationLegalReserve', value);
+        formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', value);
+        formik.setFieldValue('AppAroundSpringsWaterEyes', value);
+        formik.setFieldValue('AppHillside', value);
+        formik.setFieldValue('AppHillTop', value);
+        formik.setFieldValue('EnvironmentalRegularizationPlan', value);
+        formik.setFieldValue('WaterGrant', value);
+    };
 
-        <Header />
-        <Text style={styles.tipsTitle}>
-          Selecione abaixo as características de sua propriedade em relação a legislação ambiental
-        </Text>
-        
-        <ScrollView style={styles.stepList} showsVerticalScrollIndicator={false}>
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('EnvironmentalLicensing', !formik.values.EnvironmentalLicensing)
-            formik.setFieldValue('CAR', true)
-            formik.setFieldValue('NativeVegetationLegalReserve', true)
-            formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', true)
-            formik.setFieldValue('AppAroundSpringsWaterEyes', true)
-            formik.setFieldValue('AppHillside', true)
-            formik.setFieldValue('AppHillTop', true)
-            formik.setFieldValue('EnvironmentalRegularizationPlan', true)
-            formik.setFieldValue('WaterGrant', true)
-        }}>
-            <Text style={styles.caption}>
-                Possui licenciamento ambiental?
+    return (
+        <View style={styles.container}>
+            <Header />
+            <Text style={styles.tipsTitle}>
+                Selecione abaixo as características de sua propriedade em relação a legislação ambiental
             </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('EnvironmentalLicensing', text)
-                formik.setFieldValue('CAR', true)
-                formik.setFieldValue('NativeVegetationLegalReserve', true)
-                formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', true)
-                formik.setFieldValue('AppAroundSpringsWaterEyes', true)
-                formik.setFieldValue('AppHillside', true)
-                formik.setFieldValue('AppHillTop', true)
-                formik.setFieldValue('EnvironmentalRegularizationPlan', true)
-                formik.setFieldValue('WaterGrant', true)
 
-            }}
-            value = {formik.values.EnvironmentalLicensing}
-            />
-        </TouchableOpacity>
-        {!formik.values.EnvironmentalLicensing  &&
-        <>
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('CAR', !formik.values.CAR)
-        }}>
-            <Text style={styles.caption}>
-                Possui cadastro ambiental rural - CAR?
-            </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('CAR', text)
-            }}
-            value = {formik.values.CAR}
-            />
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('NativeVegetationLegalReserve', !formik.values.NativeVegetationLegalReserve)
-        }}>
-            <Text style={styles.caption}>
-                Possui área com cobertura de vegetação nativa que atende percentual de Reserva Legal?
-            </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('NativeVegetationLegalReserve', text)
-            }}
-            value = {formik.values.NativeVegetationLegalReserve}
-            />
-        </TouchableOpacity>
-        
-        <View style={styles.containerOption}>
-            <Text style={{ ...styles.title, fontWeight: "bold"}}>
-            Possui Área de Preservação Permanente-APP em conformidade com o Código Florestal: 
-            </Text>
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', !formik.values.AppAroundWaterCoursesWaterReservoirs)
-                formik.setFieldValue('IntegralVegetation', !formik.values.AppAroundWaterCoursesWaterReservoirs)
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', !formik.values.AppAroundWaterCoursesWaterReservoirs)
-                    formik.setFieldValue('IntegralVegetation', !formik.values.AppAroundWaterCoursesWaterReservoirs)
-                }}
-                color="#A3A3A3"
-                checked = {formik.values.AppAroundWaterCoursesWaterReservoirs}
-                />
-                <Text style={styles.option}>
-                Em torno dos cursos hídricos e reservatórios de água
-                </Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('AppAroundSpringsWaterEyes', !formik.values.AppAroundSpringsWaterEyes)
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('AppAroundSpringsWaterEyes', !formik.values.AppAroundSpringsWaterEyes)
-                }}
-                color="#A3A3A3"
-                checked = {formik.values.AppAroundSpringsWaterEyes}
-                />
-                <Text style={styles.option}>
-                Em nascentes e olhos d'água
-                </Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('AppHillside', !formik.values.AppHillside)
-                formik.setFieldValue('PresenceMaintenanceVegetation', !formik.values.AppHillside)
+            <ScrollView style={styles.stepList} showsVerticalScrollIndicator={false}>
+                <TouchableOpacity
+                    style={styles.flexView}
+                    onPress={() => {
+                        const next = !formik.values.EnvironmentalLicensing;
+                        formik.setFieldValue('EnvironmentalLicensing', next);
+                        setAppFlags(true);
+                    }}
+                >
+                    <Text style={styles.caption}>Possui licenciamento ambiental?</Text>
+                    <Switch
+                        onValueChange={(text) => {
+                            formik.setFieldValue('EnvironmentalLicensing', text);
+                            setAppFlags(true);
+                        }}
+                        value={formik.values.EnvironmentalLicensing}
+                    />
+                </TouchableOpacity>
 
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('AppHillside', !formik.values.AppHillside)
-                    formik.setFieldValue('PresenceMaintenanceVegetation', !formik.values.AppHillside)
-                }}
-                color="#A3A3A3"
-                checked = {formik.values.AppHillside}
-                />
-                <Text style={styles.option}>
-                Em encostas
-                </Text>
-            </TouchableOpacity>
-        
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('AppHillTop', !formik.values.AppHillTop)
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('AppHillTop', !formik.values.AppHillTop)
-                }}
-                color="#A3A3A3"
-                checked = {formik.values.AppHillTop}
-                />
-                <Text style={styles.option}>
-                Em topo de morro
-                </Text>
-            </TouchableOpacity>
+                {!formik.values.EnvironmentalLicensing && (
+                    <>
+                        <TouchableOpacity
+                            style={styles.flexView}
+                            onPress={() => formik.setFieldValue('CAR', !formik.values.CAR)}
+                        >
+                            <Text style={styles.caption}>Possui cadastro ambiental rural - CAR?</Text>
+                            <Switch
+                                onValueChange={(text) => formik.setFieldValue('CAR', text)}
+                                value={formik.values.CAR}
+                            />
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            style={styles.flexView}
+                            onPress={() => formik.setFieldValue('NativeVegetationLegalReserve', !formik.values.NativeVegetationLegalReserve)}
+                        >
+                            <Text style={styles.caption}>
+                                Possui área com cobertura de vegetação nativa que atende percentual de Reserva Legal?
+                            </Text>
+                            <Switch
+                                onValueChange={(text) => formik.setFieldValue('NativeVegetationLegalReserve', text)}
+                                value={formik.values.NativeVegetationLegalReserve}
+                            />
+                        </TouchableOpacity>
 
+                        <View style={styles.containerOption}>
+                            <Text style={{ ...styles.title, fontWeight: 'bold' }}>
+                                Possui Área de Preservação Permanente-APP em conformidade com o Código Florestal:
+                            </Text>
+                            <TouchableOpacity
+                                style={styles.flexViewOption}
+                                onPress={() => {
+                                    const next = !formik.values.AppAroundWaterCoursesWaterReservoirs;
+                                    formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', next);
+                                    formik.setFieldValue('IntegralVegetation', next);
+                                }}
+                            >
+                                <CheckBox
+                                    onPress={() => {
+                                        const next = !formik.values.AppAroundWaterCoursesWaterReservoirs;
+                                        formik.setFieldValue('AppAroundWaterCoursesWaterReservoirs', next);
+                                        formik.setFieldValue('IntegralVegetation', next);
+                                    }}
+                                    color="#A3A3A3"
+                                    checked={formik.values.AppAroundWaterCoursesWaterReservoirs}
+                                />
+                                <Text style={styles.option}>Em torno dos cursos hídricos e reservatórios de água</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                style={styles.flexViewOption}
+                                onPress={() => formik.setFieldValue('AppAroundSpringsWaterEyes', !formik.values.AppAroundSpringsWaterEyes)}
+                            >
+                                <CheckBox
+                                    onPress={() => formik.setFieldValue('AppAroundSpringsWaterEyes', !formik.values.AppAroundSpringsWaterEyes)}
+                                    color="#A3A3A3"
+                                    checked={formik.values.AppAroundSpringsWaterEyes}
+                                />
+                                <Text style={styles.option}>Em nascentes e olhos d'água</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                style={styles.flexViewOption}
+                                onPress={() => {
+                                    const next = !formik.values.AppHillside;
+                                    formik.setFieldValue('AppHillside', next);
+                                    formik.setFieldValue('PresenceMaintenanceVegetation', next);
+                                }}
+                            >
+                                <CheckBox
+                                    onPress={() => {
+                                        const next = !formik.values.AppHillside;
+                                        formik.setFieldValue('AppHillside', next);
+                                        formik.setFieldValue('PresenceMaintenanceVegetation', next);
+                                    }}
+                                    color="#A3A3A3"
+                                    checked={formik.values.AppHillside}
+                                />
+                                <Text style={styles.option}>Em encostas</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                style={styles.flexViewOption}
+                                onPress={() => formik.setFieldValue('AppHillTop', !formik.values.AppHillTop)}
+                            >
+                                <CheckBox
+                                    onPress={() => formik.setFieldValue('AppHillTop', !formik.values.AppHillTop)}
+                                    color="#A3A3A3"
+                                    checked={formik.values.AppHillTop}
+                                />
+                                <Text style={styles.option}>Em topo de morro</Text>
+                            </TouchableOpacity>
+                        </View>
+
+                        <TouchableOpacity
+                            style={styles.flexView}
+                            onPress={() => formik.setFieldValue('EnvironmentalRegularizationPlan', !formik.values.EnvironmentalRegularizationPlan)}
+                        >
+                            <Text style={styles.caption}>Possui Plano de Regularização Ambiental?</Text>
+                            <Switch
+                                onValueChange={(text) => formik.setFieldValue('EnvironmentalRegularizationPlan', text)}
+                                value={formik.values.EnvironmentalRegularizationPlan}
+                            />
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            style={styles.flexView}
+                            onPress={() => formik.setFieldValue('WaterGrant', !formik.values.WaterGrant)}
+                        >
+                            <Text style={styles.caption}>Possui outorga de uso da água?</Text>
+                            <Switch
+                                onValueChange={(text) => formik.setFieldValue('WaterGrant', text)}
+                                value={formik.values.WaterGrant}
+                            />
+                        </TouchableOpacity>
+                    </>
+                )}
+                {formik.values.EnvironmentalLicensing && (
+                    <View style={styles.congratulation}>
+                        <Feather name="activity" size={35} color="#00753E" />
+                        <Text>
+                            Parabéns! Se sua propridade já possui licenciamento ambiental, ela se encontra em conformidade com a legislação ambiental.
+                        </Text>
+                    </View>
+                )}
+                <TouchableOpacity style={styles.Button} onPress={formik.handleSubmit}>
+                    {formik.isSubmitting ? (
+                        <>
+                            <Text style={styles.ButtonText}>Salvando </Text>
+                            <ActivityIndicator color="#fff" size="large" />
+                        </>
+                    ) : (
+                        <Text style={styles.ButtonText}>Salvar</Text>
+                    )}
+                </TouchableOpacity>
+            </ScrollView>
         </View>
-
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('EnvironmentalRegularizationPlan', !formik.values.EnvironmentalRegularizationPlan)
-        }}>
-            <Text style={styles.caption}>
-                Possui Plano de Regularização Ambiental?
-            </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('EnvironmentalRegularizationPlan', text)
-            }}
-            value = {formik.values.EnvironmentalRegularizationPlan}
-            />
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('WaterGrant', !formik.values.WaterGrant)
-        }}>
-            <Text style={styles.caption}>
-                Possui outorga de uso da água?
-            </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('WaterGrant', text)
-            }}
-            value = {formik.values.WaterGrant}
-            />
-        </TouchableOpacity>
-        </>
-        }
-        {formik.values.EnvironmentalLicensing  && <View style={styles.congratulation}>
-            <Feather name='activity' size={35} color='#00753E' />
-            <Text>
-                Parabéns! Se sua propridade já possui licenciamento ambiental, ela se encontra em conformidade com a legislação ambiental.
-            </Text>
-        </View>
-        }
-        <TouchableOpacity
-        style={styles.Button}
-        onPress={formik.handleSubmit}
-        >
-        {
-          formik.isSubmitting ? 
-          <><Text style={styles.ButtonText}>Salvando </Text>
-          <ActivityIndicator color='#fff' size= 'large' /></>
-          :
-          <Text style={styles.ButtonText}>Salvar</Text>
-        }
-       
-        </TouchableOpacity>
-        </ScrollView>
-    </View>;
+    );
 }

--- a/src/pages/waterResources/index.js
+++ b/src/pages/waterResources/index.js
@@ -1,208 +1,149 @@
-import React, {useState} from 'react';
-import { View, Text, Switch, ScrollView, TouchableOpacity, ActivityIndicator,
-AsyncStorage} from 'react-native';
-import {CheckBox} from "native-base";
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
+import { CheckBox } from 'native-base';
 import { useFormik } from 'formik';
 import { useNavigation } from '@react-navigation/native';
+
+import Header from '../../utils/header';
 import createControl from '../../utils/createControl';
 import createLand from '../../utils/createLand';
 import styles from './styles';
-import Header from '../../utils/header';
+
 
 export default function WaterResource() {
-    const navigation = useNavigation()
-    const [r1,setR1] = useState(false)
-    const [r2,setR2] = useState(false)
-    const [r3,setR3] = useState(false)
-    const [r4,setR4] = useState(false)
-    
-    const control = createControl
+    const navigation = useNavigation();
+    const [r1, setR1] = useState(false);
+    const [r2, setR2] = useState(false);
+    const [r3, setR3] = useState(false);
+    const [r4, setR4] = useState(false);
+
+    const control = createControl;
+
     const formik = useFormik({
         initialValues: {
             SourceProtectedWaterMine: false,
             DomesticSewageTreatment: false,
             WaterConsuptionTreatment: false,
         },
-        handleSubmit: () => {},
-        onSubmit: async (values, {setSubmitting, setErrors}) => {
+        onSubmit: async (values, { setSubmitting }) => {
             setSubmitting(true);
-            
-            let jsonValue = JSON.parse(await AsyncStorage.getItem('land'))
-            let JSONcontrol = JSON.parse(await AsyncStorage.getItem('control'))
-            
-            let attributes = jsonValue.attributes
-            for (var key in formik.values)  {
-                attributes[key] = formik.values[key]
-            }
-            
             try {
-                jsonValue.edited = true
-                await createLand.update({
-                    ...jsonValue,
-                    attributes
-                })
-                await control.update({
-                ...JSONcontrol,
-                'boolWaterResource': true
-                })
+                const [landRaw, controlRaw] = await Promise.all([
+                    AsyncStorage.getItem('land'),
+                    AsyncStorage.getItem('control'),
+                ]);
+                const land = JSON.parse(landRaw);
+                const JSONcontrol = JSON.parse(controlRaw);
+                const attributes = { ...(land.attributes ?? {}), ...values };
+
+                land.edited = true;
+                await createLand.update({ ...land, attributes });
+                await control.update({ ...JSONcontrol, boolWaterResource: true });
                 setSubmitting(false);
                 navigation.goBack();
             } catch (error) {
-                alert('Falha no armazenamento, tente mais uma vez.')
+                console.warn('[WaterResource.onSubmit]', error);
+                alert('Falha no armazenamento, tente mais uma vez.');
                 setSubmitting(false);
                 navigation.goBack();
             }
-            
         },
-      });
+    });
 
-    return <View style={styles.container} >
+    // r1..r3 are sewage-treatment options; r4 is "none" (mutually exclusive).
+    // We compute the next state up-front so the Formik flag stays in sync.
+    const toggleSewage = (which) => {
+        const next1 = which === 'r1' ? !r1 : r1;
+        const next2 = which === 'r2' ? !r2 : r2;
+        const next3 = which === 'r3' ? !r3 : r3;
+        formik.setFieldValue('DomesticSewageTreatment', next1 || next2 || next3);
+        if (which === 'r1') setR1(next1);
+        if (which === 'r2') setR2(next2);
+        if (which === 'r3') setR3(next3);
+        setR4(false);
+    };
 
-        <Header />
-        <Text style={styles.tipsTitle}>
-          Selecione abaixo as características de sua propriedade em relação a recursos hídricos
-        </Text>
-        
-        <ScrollView style={styles.stepList} showsVerticalScrollIndicator={false}>
-        
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('SourceProtectedWaterMine', !formik.values.SourceProtectedWaterMine)
-        }}>
-            <Text style={styles.caption}>
-                Nascente ou mina de água protegida?
-            </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('SourceProtectedWaterMine', text)
-            }}
-            value = {formik.values.SourceProtectedWaterMine}
-            />
-        </TouchableOpacity>
-
-        <View style={styles.containerOption}>
-
-            <Text style={{ margin: 8, fontWeight: 'bold'}}>
-            Destinação do esgoto doméstico:
-            </Text>
-
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('DomesticSewageTreatment', 
-                    !r1 || r2 || r3
-                )       
-                setR1(!r1)
-                setR4(false)
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('DomesticSewageTreatment', 
-                        !r1 || r2 || r3
-                    )
-                    setR1(!r1)
-                    setR4(false)
-
-                }}
-                color="#A3A3A3"
-                checked = {r1}
-                />
-                <Text style={styles.option}>
-                Fossa biodigestora
-                </Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('DomesticSewageTreatment', 
-                    r1 || !r2 || r3
-                )
-                setR2(!r2)
-                setR4(false)
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('DomesticSewageTreatment', 
-                        r1 || !r2 || r3
-                    )
-                    setR2(!r2)
-                    setR4(false)
-                }}
-                color="#A3A3A3"
-                checked = {r2}
-                />
-                <Text style={styles.option}>
-                Fossa negra/infiltração
-                </Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                formik.setFieldValue('DomesticSewageTreatment', 
-                    r1 || r2 || !r3
-                )
-                setR3(!r3)
-                setR4(false)
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    formik.setFieldValue('DomesticSewageTreatment', 
-                        r1 || r2 || !r3
-                    )
-                    setR3(!r3)
-                    setR4(false)
-                }}
-                color="#A3A3A3"
-                checked = {r3}
-                />
-                <Text style={styles.option}>
-                Outra
-                </Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.flexViewOption} onPress={async () => {
-                setR4(!r4)
-                setR1(false)
-                setR2(false)
-                setR3(false)
-                formik.setFieldValue('DomesticSewageTreatment', false)    
-            }}>
-                <CheckBox 
-                onPress = {() => {
-                    setR4(!r4)
-                    setR1(false)
-                    setR2(false)
-                    setR3(false)
-                    formik.setFieldValue('DomesticSewageTreatment', false)
-                }}
-                color="#A3A3A3"
-                checked = {r4}
-                />
-                <Text style={styles.option}>
-                Nenhum
-                </Text>
-            </TouchableOpacity>        
-        </View>
-        
-        <TouchableOpacity style={styles.flexView} onPress={async () => {
-            formik.setFieldValue('WaterConsuptionTreatment', !formik.values.WaterConsuptionTreatment)
-        }}>
-            <Text style={styles.caption}>
-                Água de consumo humano/animal e para limpeza tratada
-            </Text>
-            <Switch 
-            onValueChange = {text => {
-                formik.setFieldValue('WaterConsuptionTreatment', text)
-            }}
-            value = {formik.values.WaterConsuptionTreatment}
-            />
-        </TouchableOpacity>
-
-        <TouchableOpacity
-        style={styles.Button}
-        onPress={formik.handleSubmit}
-        >
-        {
-          formik.isSubmitting ? 
-          <><Text style={styles.ButtonText}>Salvando </Text>
-          <ActivityIndicator color='#fff' size= 'large' /></>
-          :
-          <Text style={styles.ButtonText}>Salvar</Text>
+    const toggleNone = () => {
+        const next = !r4;
+        setR4(next);
+        if (next) {
+            setR1(false);
+            setR2(false);
+            setR3(false);
+            formik.setFieldValue('DomesticSewageTreatment', false);
         }
-       
-        </TouchableOpacity>
-        </ScrollView>
-    </View>;
+    };
+
+    return (
+        <View style={styles.container}>
+            <Header />
+            <Text style={styles.tipsTitle}>
+                Selecione abaixo as características de sua propriedade em relação a recursos hídricos
+            </Text>
+
+            <ScrollView style={styles.stepList} showsVerticalScrollIndicator={false}>
+                <TouchableOpacity
+                    style={styles.flexView}
+                    onPress={() => formik.setFieldValue('SourceProtectedWaterMine', !formik.values.SourceProtectedWaterMine)}
+                >
+                    <Text style={styles.caption}>Nascente ou mina de água protegida?</Text>
+                    <Switch
+                        onValueChange={(text) => formik.setFieldValue('SourceProtectedWaterMine', text)}
+                        value={formik.values.SourceProtectedWaterMine}
+                    />
+                </TouchableOpacity>
+
+                <View style={styles.containerOption}>
+                    <Text style={{ margin: 8, fontWeight: 'bold' }}>Destinação do esgoto doméstico:</Text>
+
+                    <TouchableOpacity style={styles.flexViewOption} onPress={() => toggleSewage('r1')}>
+                        <CheckBox onPress={() => toggleSewage('r1')} color="#A3A3A3" checked={r1} />
+                        <Text style={styles.option}>Fossa biodigestora</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.flexViewOption} onPress={() => toggleSewage('r2')}>
+                        <CheckBox onPress={() => toggleSewage('r2')} color="#A3A3A3" checked={r2} />
+                        <Text style={styles.option}>Fossa negra/infiltração</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.flexViewOption} onPress={() => toggleSewage('r3')}>
+                        <CheckBox onPress={() => toggleSewage('r3')} color="#A3A3A3" checked={r3} />
+                        <Text style={styles.option}>Outra</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.flexViewOption} onPress={toggleNone}>
+                        <CheckBox onPress={toggleNone} color="#A3A3A3" checked={r4} />
+                        <Text style={styles.option}>Nenhum</Text>
+                    </TouchableOpacity>
+                </View>
+
+                <TouchableOpacity
+                    style={styles.flexView}
+                    onPress={() => formik.setFieldValue('WaterConsuptionTreatment', !formik.values.WaterConsuptionTreatment)}
+                >
+                    <Text style={styles.caption}>Água de consumo humano/animal e para limpeza tratada</Text>
+                    <Switch
+                        onValueChange={(text) => formik.setFieldValue('WaterConsuptionTreatment', text)}
+                        value={formik.values.WaterConsuptionTreatment}
+                    />
+                </TouchableOpacity>
+
+                <TouchableOpacity style={styles.Button} onPress={formik.handleSubmit}>
+                    {formik.isSubmitting ? (
+                        <>
+                            <Text style={styles.ButtonText}>Salvando </Text>
+                            <ActivityIndicator color="#fff" size="large" />
+                        </>
+                    ) : (
+                        <Text style={styles.ButtonText}>Salvar</Text>
+                    )}
+                </TouchableOpacity>
+            </ScrollView>
+        </View>
+    );
 }

--- a/src/utils/createControl.js
+++ b/src/utils/createControl.js
@@ -1,53 +1,47 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
-function createControl() {
-  
-  async function getData(){
-    try{ 
-      let jsonValue = await AsyncStorage.getItem('control');
-      
-      return jsonValue != null ? JSON.parse(jsonValue): {
-        boolCaracterization : false,
-        boolProduction : false,
-        boolLegislation :  false,
-        boolWaterResource :  false,
-        boolSoilVegetation : false,
-        boolWasteManagement :  false,
-      } 
-    } catch(err) {
-      console.warn(err)
-    }
+
+const STORAGE_KEY = 'control';
+
+const defaultControl = () => ({
+  boolCaracterization: false,
+  boolProduction: false,
+  boolLegislation: false,
+  boolWaterResource: false,
+  boolSoilVegetation: false,
+  boolWasteManagement: false,
+});
+
+async function getData() {
+  try {
+    const jsonValue = await AsyncStorage.getItem(STORAGE_KEY);
+    return jsonValue != null ? JSON.parse(jsonValue) : defaultControl();
+  } catch (err) {
+    console.warn('[createControl.getData]', err);
+    return defaultControl();
   }
-
-
-  async function update(data = null){
-    try{ 
-      if (data != null) {
-        let jsonValue = await AsyncStorage.setItem('control', JSON.stringify(data));
-        return true
-      }
-      return false;
-    } catch(err) {
-      console.warn(err)
-      return false;
-    }
-  }
-
-  async function clean(){
-    try{
-      await AsyncStorage.removeItem('control');
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }
-  
-  return {
-    getData,
-    update,
-    clean
-  }
-
 }
 
-export default createControl();
+async function update(data) {
+  if (data == null) return false;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    return true;
+  } catch (err) {
+    console.warn('[createControl.update]', err);
+    return false;
+  }
+}
+
+async function clean() {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    return true;
+  } catch (err) {
+    console.warn('[createControl.clean]', err);
+    return false;
+  }
+}
+
+const createControl = { getData, update, clean };
+export default createControl;

--- a/src/utils/createLand.js
+++ b/src/utils/createLand.js
@@ -1,83 +1,72 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
+
 import api from '../services/api';
 import createControl from './createControl';
 import UniqueID from './createUniqueIDFarm';
 
-function createLand() {
-  
-  async function getData(){
-    try{ 
-      const jsonValue = await AsyncStorage.getItem('land');
-      if (jsonValue != null) {
-        let jsonValueParsed = JSON.parse(jsonValue);
-        try {
-          let response = await api.get(`farms/${jsonValueParsed.id}`)
-          return response.data;
-        } catch(err) {
 
-          let installation_id = await UniqueID.getData();
-          let data = {
-            id: jsonValueParsed.id,
-            installation_id,
-            hectare:jsonValueParsed.hectare,
-            licensing:jsonValueParsed.licensing,
-            city_id: jsonValueParsed.city.id,
-          }
-          api.post('farms', data)
-          .then(async (response) => {
-            newLand = response.data;
-            this.update(newLand);
-          })
-          .catch(err => {console.log(err);});
+const STORAGE_KEY = 'land';
 
-   
-          return jsonValueParsed;
-        }
-      } else {
-        return clean()
-      }
-    } catch(err) {
-      console.warn(err)
-    }
-  }
+const emptyLand = () => ({
+  id: null,
+  installation_id: null,
+  hectare: null,
+  licensing: null,
+  city: { biomes: [], state: {} },
+  size: null,
+  productions: {},
+});
 
-  async function update(data = null){
-    try{ 
-      if (data != null) {
-        await AsyncStorage.setItem('land', JSON.stringify(data));
-        return true
-      }
-      return false;
-    } catch(err) {
-      console.warn(err)
-      return false;
-    }
-  }
+async function clean() {
+  await createControl.clean();
+  return emptyLand();
+}
 
-  async function clean(){
-    let control = createControl;
-    
-    await control.clean();
-
-    return {
-      "id": null,
-      "installation_id": null,
-      "hectare": null,
-      "licensing": null,
-      "city": {
-        "biomes":[],
-        "state": {}
-      },
-      "size": null,
-      "productions": {}
-    }
-  }
-  
-  return {
-    getData,
-    update,
-    clean
+async function update(data) {
+  if (data == null) return false;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    return true;
+  } catch (err) {
+    console.warn('[createLand.update]', err);
+    return false;
   }
 }
 
-export default createLand();
+async function getData() {
+  try {
+    const jsonValue = await AsyncStorage.getItem(STORAGE_KEY);
+    if (jsonValue == null) return clean();
+
+    const parsed = JSON.parse(jsonValue);
+
+    try {
+      const response = await api.get(`farms/${parsed.id}`);
+      return response.data;
+    } catch (err) {
+      // Farm missing on the backend; try to recreate and persist the fresh copy.
+      try {
+        const installationId = await UniqueID.getData();
+        const payload = {
+          id: parsed.id,
+          installation_id: installationId,
+          hectare: parsed.hectare,
+          licensing: parsed.licensing,
+          city_id: parsed.city?.id,
+        };
+        const response = await api.post('farms', payload);
+        await update(response.data);
+        return response.data;
+      } catch (postErr) {
+        console.warn('[createLand.getData] recreate failed', postErr);
+        return parsed;
+      }
+    }
+  } catch (err) {
+    console.warn('[createLand.getData]', err);
+    return clean();
+  }
+}
+
+const createLand = { getData, update, clean };
+export default createLand;

--- a/src/utils/createUniqueIDFarm.js
+++ b/src/utils/createUniqueIDFarm.js
@@ -1,38 +1,31 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
-function createUUID() {
-  
-  async function getData(){
-    try{ 
-      let jsonValue = await AsyncStorage.getItem('UniqueIDFarm');
-      return jsonValue != null ? JSON.parse(jsonValue): null;
-    } catch(err) {
-      console.warn(err)
-    }
+
+const STORAGE_KEY = 'UniqueIDFarm';
+
+async function getData() {
+  try {
+    const jsonValue = await AsyncStorage.getItem(STORAGE_KEY);
+    return jsonValue != null ? JSON.parse(jsonValue) : null;
+  } catch (err) {
+    console.warn('[createUniqueIDFarm.getData]', err);
+    return null;
   }
-
-  async function update(data){
-    try{ 
-
-      await AsyncStorage.setItem('UniqueIDFarm', JSON.stringify(data));
-      return true;
-      
-    } catch(err) {
-      console.warn(err)
-      return false;
-    }
-  }
-
-  async function addFarm() {
-    return false;
-  }
-  
-  return {
-    getData,
-    update,
-    addFarm
-  }
-
 }
 
-export default createUUID();
+async function update(data) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    return true;
+  } catch (err) {
+    console.warn('[createUniqueIDFarm.update]', err);
+    return false;
+  }
+}
+
+async function addFarm() {
+  return false;
+}
+
+const createUniqueIDFarm = { getData, update, addFarm };
+export default createUniqueIDFarm;


### PR DESCRIPTION
- blankScreen/index.js: replace call to undefined `sleep()` with setTimeout
  + cleanup; screen used to throw ReferenceError and never navigate home
- createLand.js:
  * replaces broken `this.update(newLand)` inside arrow function (was
    running in undefined context)
  * replaces implicit global `newLand = response.data`
  * awaits api.post before returning so callers don't get stale data
  * defensive optional chaining on parsed.city?.id
- createUniqueIDFarm.js, createControl.js, citySearch/index.js:
  switch AsyncStorage import from the deprecated react-native core export
  to @react-native-community/async-storage (already in package.json)
- citySearch/index.js: use item.id as keyExtractor (was array index,
  causing incorrect re-renders)